### PR TITLE
:sparkles: Add server and ssh key labels for temporary objects

### DIFF
--- a/builder/hcloud/config.go
+++ b/builder/hcloud/config.go
@@ -31,12 +31,13 @@ type Config struct {
 
 	PollInterval time.Duration `mapstructure:"poll_interval"`
 
-	ServerName        string       `mapstructure:"server_name"`
-	Location          string       `mapstructure:"location"`
-	ServerType        string       `mapstructure:"server_type"`
-	UpgradeServerType string       `mapstructure:"upgrade_server_type"`
-	Image             string       `mapstructure:"image"`
-	ImageFilter       *imageFilter `mapstructure:"image_filter"`
+	ServerName        string            `mapstructure:"server_name"`
+	Location          string            `mapstructure:"location"`
+	ServerType        string            `mapstructure:"server_type"`
+	ServerLabels      map[string]string `mapstructure:"server_labels"`
+	UpgradeServerType string            `mapstructure:"upgrade_server_type"`
+	Image             string            `mapstructure:"image"`
+	ImageFilter       *imageFilter      `mapstructure:"image_filter"`
 
 	SnapshotName   string            `mapstructure:"snapshot_name"`
 	SnapshotLabels map[string]string `mapstructure:"snapshot_labels"`
@@ -44,6 +45,8 @@ type Config struct {
 	UserDataFile   string            `mapstructure:"user_data_file"`
 	SSHKeys        []string          `mapstructure:"ssh_keys"`
 	Networks       []int64           `mapstructure:"networks"`
+
+	TempSSHKeyLabels map[string]string `mapstructure:"temp_sshkey_labels"`
 
 	RescueMode string `mapstructure:"rescue"`
 

--- a/builder/hcloud/step_create_server.go
+++ b/builder/hcloud/step_create_server.go
@@ -82,6 +82,7 @@ func (s *stepCreateServer) Run(ctx context.Context, state multistep.StateBag) mu
 		Location:   &hcloud.Location{Name: c.Location},
 		UserData:   userData,
 		Networks:   networks,
+		Labels:     c.ServerLabels,
 	}
 
 	if c.UpgradeServerType != "" {
@@ -89,7 +90,6 @@ func (s *stepCreateServer) Run(ctx context.Context, state multistep.StateBag) mu
 	}
 
 	serverCreateResult, _, err := client.Server.Create(ctx, serverCreateOpts)
-
 	if err != nil {
 		err := fmt.Errorf("Error creating server: %s", err)
 		state.Put("error", err)
@@ -127,7 +127,6 @@ func (s *stepCreateServer) Run(ctx context.Context, state multistep.StateBag) mu
 			ServerType:  &hcloud.ServerType{Name: c.UpgradeServerType},
 			UpgradeDisk: false,
 		})
-
 		if err != nil {
 			err := fmt.Errorf("Error changing server-type: %s", err)
 			state.Put("error", err)
@@ -144,7 +143,6 @@ func (s *stepCreateServer) Run(ctx context.Context, state multistep.StateBag) mu
 
 		ui.Say("Starting server...")
 		serverPoweronAction, _, err := client.Server.Poweron(ctx, serverCreateResult.Server)
-
 		if err != nil {
 			err := fmt.Errorf("Error starting server: %s", err)
 			state.Put("error", err)
@@ -256,7 +254,7 @@ func waitForAction(ctx context.Context, client *hcloud.Client, action *hcloud.Ac
 func getImageWithSelectors(ctx context.Context, client *hcloud.Client, c *Config, serverType *hcloud.ServerType) (*hcloud.Image, error) {
 	var allImages []*hcloud.Image
 
-	var selector = strings.Join(c.ImageFilter.WithSelector, ",")
+	selector := strings.Join(c.ImageFilter.WithSelector, ",")
 	opts := hcloud.ImageListOpts{
 		ListOpts:     hcloud.ListOpts{LabelSelector: selector},
 		Status:       []hcloud.ImageStatus{hcloud.ImageStatusAvailable},

--- a/builder/hcloud/step_create_sshkey.go
+++ b/builder/hcloud/step_create_sshkey.go
@@ -36,6 +36,7 @@ func (s *stepCreateSSHKey) Run(ctx context.Context, state multistep.StateBag) mu
 	key, _, err := client.SSHKey.Create(ctx, hcloud.SSHKeyCreateOpts{
 		Name:      name,
 		PublicKey: string(c.Comm.SSHPublicKey),
+		Labels:    c.TempSSHKeyLabels,
 	})
 	if err != nil {
 		err := fmt.Errorf("Error creating temporary SSH key: %s", err)


### PR DESCRIPTION
Adding labels to the temporary server and ssh key objects which are needed to create the snapshot.

This is needed in some use cases where e.g. packer build stops unexpectedly due to a SIGKILL and cannot shut down properly. In order to realize that the respective server and ssh key are orphaned, labels are needed.
